### PR TITLE
Use Chromecontainer and Playwright like in our failure scenario

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <description>Project to reproduce networking issues between Testcontainers and Podman Desktop</description>
     
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <testcontainers.version>1.19.8</testcontainers.version>
         <junit.version>5.10.0</junit.version>
@@ -63,6 +63,19 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.9</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.40</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>1.55.0</version>
         </dependency>
     </dependencies>
     

--- a/src/main/java/com/example/HostAddresses.java
+++ b/src/main/java/com/example/HostAddresses.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import lombok.Generated;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public final class HostAddresses {
+    public static final String HOST_ADDRESS;
+
+    @Generated
+    private HostAddresses() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    static {
+        try {
+            HOST_ADDRESS = InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException ex) {
+            throw new IllegalStateException("Local host name could not be resolved.", ex);
+        }
+    }
+}

--- a/src/main/java/com/example/HostApplication.java
+++ b/src/main/java/com/example/HostApplication.java
@@ -26,7 +26,7 @@ public class HostApplication {
         System.out.println("Detected LAN IP: " + lanIpAddress);
         
         // Create HTTP server bound to the LAN IP
-        InetSocketAddress address = new InetSocketAddress(lanIpAddress, PORT);
+        InetSocketAddress address = new InetSocketAddress("0.0.0.0", PORT);
         this.server = HttpServer.create(address, 0);
         
         // Add handlers

--- a/src/test/java/com/example/ChromeContainer.java
+++ b/src/test/java/com/example/ChromeContainer.java
@@ -1,0 +1,61 @@
+package com.example;
+
+import com.github.dockerjava.api.model.*;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public final class ChromeContainer extends GenericContainer<ChromeContainer> {
+
+    private static final int PORT = 9222;
+
+    private String cdpAddress = null;
+
+    public ChromeContainer( final String dockerImageName ) {
+        super( dockerImageName );
+        this
+                .withCreateContainerCmdModifier( it -> it.withHostConfig( HostConfig.newHostConfig( )
+                        .withCapAdd( Capability.SYS_ADMIN )
+                        .withPortBindings( new PortBinding( Ports.Binding.empty( ), ExposedPort.tcp( PORT ) ) ) ) )
+                .withAccessToHost( true )
+                .withExposedPorts( PORT )
+                .waitingFor( Wait.forHttp( "/" ) );
+        setStartupAttempts( 3 );
+    }
+
+    public ChromeContainer( final DockerImageName dockerImageName ) {
+        this( dockerImageName.asCanonicalNameString( ) );
+    }
+
+    @Override
+    public void start( ) {
+        super.start( );
+    }
+
+    public String getCDPAddress( ) throws URISyntaxException, IOException {
+        if ( cdpAddress == null ) {
+            final URL url = new URI( "http", String.format( "%s:%s", getHost( ), getFirstMappedPort( ) ), "/json/version", null, null ).toURL( );
+            final ObjectMapper mapper = new ObjectMapper( );
+            cdpAddress = mapper.readTree( url ).get( "webSocketDebuggerUrl" ).textValue( );
+        }
+
+        return cdpAddress;
+    }
+
+    @Override
+    public boolean equals( final Object o ) {
+        return this == o;
+    }
+
+    @Override
+    public int hashCode( ) {
+        return System.identityHashCode( this );
+    }
+
+}


### PR DESCRIPTION
I tried to get the scenario closer to our real  use case. Since I don't know for sure where the problem could lie, that means:

- use Java 21
- use a different Chromium image for headless Chromium
- use Playwright to make Chromium access the host
- use exact same method to determine host IP, although this should be interchangeable
- added one new method just trying to make Chromium navigate to the host address
- quick access to other browser modes so you can see that direct access on host works

What I observed:
- fails when Podman Desktop is open
- runs when Podman Desktop is closed
- **always works when host server is directly bound to my LAN IP, instead of 0.0.0.0**

Additionally, I tried just binding to 0.0.0.0 in your test scenario, without changing ANY of the container setups. So the only change was in HostApplication.java#29. This changed nothing, even with Podman Desktop open, it would still be able to access the host, even with Podman Desktop opened. **Using your shell script.**